### PR TITLE
Fix example merging

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -53,10 +53,23 @@ var helpers = module.exports = {
         }
       }
 
+
       // Added this guard clause to prevent errors
       // caused by trying to index into object b when it doesn't exist
       if (a && b){
-        result[k] = helpers.mergeJson(a[k], b[k]);
+        var merged = helpers.mergeJson(a[k], b[k]);
+        // This check is here for examples that have keys set to 'false'
+        // Without this, the merge makes the value 'undefined' and then it's dropped from
+        // the final output
+        if(merged === undefined){
+          if(b[k] === false){
+            result[k] = b[k];
+          } else {
+            result[k] = a[k]
+          }
+        } else {
+          result[k] = merged;
+        }
       } else if (b) {
         result[k] = b[k];
       } else {

--- a/test/fixtures/exampleTestingParentSpec/endpoints/products.md
+++ b/test/fixtures/exampleTestingParentSpec/endpoints/products.md
@@ -1,0 +1,13 @@
+# Group Products
+
+## Products [/product]
+
+Represents the collection of products.
+
+### Get Product [GET]
+
+Returns a product.
+
++ Response 200
+
+            {{example 'product'}}

--- a/test/fixtures/exampleTestingParentSpec/examples/product.json
+++ b/test/fixtures/exampleTestingParentSpec/examples/product.json
@@ -1,0 +1,36 @@
+{
+  "id": "1234",
+  "name": "Jam",
+  "price": 45.0,
+  "discountedPrice": 40.0,
+  "description": "A Product that is sold",
+  "imageResources": {
+    "1": [
+      {
+        "url": "http://www.url1.jpg",
+        "usage": "thumbnail"
+      },
+      {
+        "url": "http://www.url2.jpg",
+        "usage": "small"
+      },
+      {
+        "url": "http://www.url3.jpg",
+        "usage": "large"
+      }
+    ],
+    "2": [
+      {
+        "url": "http://www.url4.jpg",
+        "usage": "thumbnail"
+      },
+      {
+        "url": "http://www.url6.jpg",
+        "usage": "large"
+      }
+    ]
+  },
+  "imageIds": ["1", "2"],
+  "categoryIds": [ "1", "2", "5"],
+  "wishlistIds": ["1", "2", "5"]
+}

--- a/test/fixtures/exampleTestingParentSpec/spec.json
+++ b/test/fixtures/exampleTestingParentSpec/spec.json
@@ -1,0 +1,5 @@
+{
+  "features": [
+    "endpoints/products"
+  ]
+}

--- a/test/fixtures/exampleTestingSpec/examples/product.json
+++ b/test/fixtures/exampleTestingSpec/examples/product.json
@@ -1,0 +1,11 @@
+{
+  "hasPriceRange": false,
+  "styleNumber": "9001",
+  "giftCardType": "certificate",
+  "skus": [
+    {
+      "isInWishlist": false
+    }
+  ],
+  "otherPrintsAvailable": false
+}

--- a/test/fixtures/exampleTestingSpec/spec.json
+++ b/test/fixtures/exampleTestingSpec/spec.json
@@ -1,0 +1,6 @@
+{
+  "inherit": "../exampleTestingParentSpec",
+  "features": [
+    "endpoints/products"
+  ]
+}

--- a/test/suite.js
+++ b/test/suite.js
@@ -327,6 +327,16 @@ describe('Spec', function () {
       describe('overriding properties', function () {
 
       });
+
+      describe('Examples', function(){
+        it('merge properly when a key is false', function(){
+          var exampleTestingSpec = Spec.load('./test/fixtures/exampleTestingSpec').call('renderBlueprint');
+          return exampleTestingSpec.then(function(blueprint){
+            console.log(blueprint);
+            blueprint.indexOf('"otherPrintsAvailable": false').should.not.equal(-1);
+          });
+        })
+      })
     });
 
     describe('__exclude', function () {


### PR DESCRIPTION
Added a check when merging JSON to properly merge keys that are 'false'. They were previously evaluating to undefined, and then not being displayed in the final blueprint file.