### PR TITLE
Protect jsonModifiers merge logic against unexisting indexes

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -61,21 +61,20 @@ var helpers = module.exports = {
     // If it does, replace the value at that key with the results of
     // merging the value at that key in the parent and child.
     _.each(keys, function (k) {
-      if (/^__/.test(k)) {
-        var modifier = _.indexBy(jsonModifiers, 'key')[k];
-
-        if (modifier) {
-          if (modifier.mergeArgs) {
-            result[k] = modifier.mergeArgs(a[k], b[k]);
-            return;
-          }
-        }
-      }
-
-
       // Added this guard clause to prevent errors
       // caused by trying to index into object b when it doesn't exist
       if (a && b){
+        if (/^__/.test(k)) {
+          var modifier = _.indexBy(helpers.jsonModifiers, 'key')[k];
+
+          if (modifier) {
+            if (modifier.mergeArgs) {
+              result[k] = modifier.mergeArgs(a[k], b[k]);
+              return;
+            }
+          }
+        }
+
         var merged = helpers.mergeJson(a[k], b[k]);
         // This check is here for examples that have keys set to 'false'
         // Without this, the merge makes the value 'undefined' and then it's dropped from

--- a/test/suite.js
+++ b/test/suite.js
@@ -38,6 +38,32 @@ describe('Helpers', function () {
       return merged.prop1.should.equal('red');
 
     });
+
+    it("should not try to merge nested json modifiers if the parent has them but the child doesn't", function () {
+      var childObject = {
+        name: 'name'
+      };
+      var parentObject = {
+        name: 'new name',
+        address: {
+          '__include': ['address1'],
+          address1: 'address line number 1',
+          address2: 'address line number 2'
+        }
+      };
+      var expectedResult = {
+        name: 'name',
+        address: {
+          '__include': ['address1'],
+          address1: 'address line number 1',
+          address2: 'address line number 2'
+        }
+      };
+
+      var merged = helpers.mergeJson(parentObject, childObject);
+
+      merged.should.deepEqual(expectedResult);
+    });
   });
 });
 


### PR DESCRIPTION
It's most likely to happen while using `__extends`. However, `__include` was chosen for the test because it doesn't require a RenderContext to load files.